### PR TITLE
feat: update readme with events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ If you join one of our office hours, this is what you can expect:
 
 - Subscribe to this Google Calendar by adding `c_pjqbs3u9afudmb2ebjb701eph8@group.calendar.google.com` to your Google Calendar.
 - The iCal version [is avaliable here.](https://calendar.google.com/calendar/ical/c_pjqbs3u9afudmb2ebjb701eph8%40group.calendar.google.com/public/basic.ics)
+
+## Past Events
+
+* 5th January 2022 - [Gitpod AMA](./2022/01/2022-01-05.md)
+* 16th December 2021 - [Gitpod self-hosted installer demo](./2021/12/2021-12-16.md)
+* 8th December 2021 - [Auto-generating the `gitpod.yml`](./2021/12/2021-12-08.md)


### PR DESCRIPTION
Suggestion to add the past event links to the README with their (main) topic area. 

Why? Because I'm a lemon 🍋 and I missed them at first glance (e.g. I didn't realise the notes were in the repo).

Also, it makes it easier to see the following (at a glance): 
* What were the past topics (to get a feel for the content)
* See the frequency / cadence (shows folks how often they occur, and how consistent we are with them)