### PR TITLE
fix: `full code` url path of Auto Gitpodifyer

### DIFF
--- a/2021/12/2021-12-08.md
+++ b/2021/12/2021-12-08.md
@@ -32,7 +32,7 @@ node app.js
 
 - if (`package.json`) --> `npm install` (OR if `yarn.lock` --> `yarn install`)
 
-- ... see [the full code](https://github.com/gitpod-io/gitpod/blob/main/components/server/src/projects/config-inferrer.ts)
+- ... see [the full code](https://github.com/gitpod-io/gitpod/blob/main/components/server/src/config/config-inferrer.ts)
 
 ### When?
 


### PR DESCRIPTION
## Description
Correct the path for Auto Gitpodifyer code.

## How to test
- go to [AutoGitpodifyer](https://github.com/gitpod-io/community-office-hours/blob/main/2021/12/2021-12-08.md#how)
- Click on the `see the full code`, it will redirect to the wrong path and gives 404 error.
